### PR TITLE
Auto Tagger & Auto Releaser (Negative Test Case)

### DIFF
--- a/.github/workflows/push-tag-🏎️.yml
+++ b/.github/workflows/push-tag-🏎️.yml
@@ -1,4 +1,4 @@
-name: Create Tag
+name: Push Tag
 
 # Only run if a commit is pushed to main (also includes PR's merged)
 on:
@@ -25,7 +25,7 @@ jobs:
           git_tag_prefix: v
 
   push_tag:
-    name: Push Tag to GitHub
+    name: Push the Latest Tag to GitHub
     runs-on: ubuntu-latest
     needs: get_package_version
     steps:

--- a/.github/workflows/release-code-🚀.yml
+++ b/.github/workflows/release-code-🚀.yml
@@ -1,4 +1,4 @@
-name: Release the Latest Tag
+name: Release Code
 
 # Invoke the workflow after the Create Tag workflow has succeeded
 on:
@@ -10,7 +10,7 @@ jobs:
   release_tag:
     name: Tagged Release 
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == success }}
 
     steps:
       - uses: actions/checkout@v2.2.0
@@ -18,9 +18,9 @@ jobs:
           fetch-depth: 0 # Required due to the way Git works; without it, this action won't be able to find any of the correct tags
       - name: Get Latest Tag
         id: latest_tag
-        uses: "WyriHaximus/github-action-get-previous-tag@v1"
+        uses: WyriHaximus/github-action-get-previous-tag@v1
 
-      - name: Release Tag
+      - name: Release the Latest Tag
         uses: marvinpinto/action-automatic-releases@v1.2.1
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Gonna use this PR for [the Goats Showcase](https://docs.google.com/spreadsheets/d/1_ayr-U90OkdFi3EQ__UrjQIfqMe_arFPcBuSk020kRM/edit#gid=0)

The workflows
1. Create Tag (`push-tag-🏎️.yml`)
    - Only run if a commit is pushed to main (also includes PR's merged)
    - Check if the package.json version exists as a tag in GitHub
    - Stop the workflow if the package.json version matches a currently existing tag
    - Else, return the package.json version as outputs.new_tag
2. Release the Latest Tag (`release-code-🚀.yml`)
    - run only if the Create Tag workflow succeeded