### PR TITLE
Auto Tagger & Auto Releaser (v3.16.0)

### DIFF
--- a/.github/workflows/push-tag-🏎️.yml
+++ b/.github/workflows/push-tag-🏎️.yml
@@ -1,6 +1,6 @@
 name: Push Tag
 
-# Only run if a commit is pushed to main (also includes PR's merged)
+# Run if a commit is pushed to main or a PR is merged to main
 on:
   push:
     branches: [main]

--- a/.github/workflows/release-code-🚀.yml
+++ b/.github/workflows/release-code-🚀.yml
@@ -1,6 +1,6 @@
 name: Release Code
 
-# Invoke the workflow after the Create Tag workflow has succeeded
+# Invoke the workflow after the Push Tag workflow has succeeded
 on:
   workflow_run:
     workflows: [Push Tag]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "experimental-code",
-  "version": "3.15.5",
+  "version": "3.16.0",
   "lockfileVersion": 2,
   "requires": true,
   "description": "",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "experimental-code",
-  "version": "3.15.5",
+  "version": "3.16.0",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
## Purpose
Standardize and simplify the tagging and release process. Release code faster and easier. Ezpz.

[This PR will be the demo for the Goats Showcase.](https://docs.google.com/spreadsheets/d/1_ayr-U90OkdFi3EQ__UrjQIfqMe_arFPcBuSk020kRM/edit#gid=0)

### The Workflows
1. Push Tag (`push-tag-🏎️.yml`)
    a. Only run if a commit is pushed to main (also includes PR's merged)
    b. Check if the package.json version exists as a tag in GitHub
    c. Stop the workflow if the package.json version matches a currently existing tag
    d. Else, return the package.json version as outputs.new_tag
2. Release Code (`release-code-🚀.yml`)
    a. Run only if the Push Tag workflow succeeded

### Pics or It Didn't Happen
![Screen Shot 2022-02-07 at 13 33 46](https://user-images.githubusercontent.com/82839521/152858871-deded387-f5c3-4297-9634-e465e2fcb6ce.png)

## Okay, BUT Did You Test It????
_Yes, I had to QA my own insanity._ :sob:

### Positive Test Cases
- [x] Run everything when a commit is pushed from `local/main` to `origin/main` ([successfully tagged v3.15.5](https://github.com/vnguyen21275/experimental-code/actions/runs/1808408646) and [successfully released v.3.15.5](https://github.com/vnguyen21275/experimental-code/releases/tag/v3.15.5))
- [ ] Run everything when a PR is merged to `origin/main`  ([pending tag for v3.16.0]() and [pending release for v.3.16.0]())


### Negative Test Case
- [x] Do not run everything when a commit is pushed from `local/main` to `origin/`main`, but the current `package.json` version matches a currently existing tag ([failed auto tagger](https://github.com/vnguyen21275/experimental-code/actions/runs/1808397897) and [skipped auto releaser](https://github.com/vnguyen21275/experimental-code/actions/runs/1808399713))
- [ ] Do not run everything when a PR is merged to `origin/main`, but the current `package.json` version matches a currently existing tag ([failed auto tagger]() and [skipped auto releaser]())
